### PR TITLE
Fixed problem with white text on white background in editor

### DIFF
--- a/formwidgets/richeditor/assets/css/richeditor.css
+++ b/formwidgets/richeditor/assets/css/richeditor.css
@@ -19,6 +19,7 @@
   overflow: visible;
   background: #fff;
   margin-bottom: 24px;
+  color: #000;
 }
 .redactor-box iframe,
 .redactor-box textarea {

--- a/formwidgets/richeditor/assets/less/_redactor.less
+++ b/formwidgets/richeditor/assets/less/_redactor.less
@@ -63,6 +63,7 @@
     overflow: visible;
     background: #fff;
     margin-bottom: 24px;
+    color: #000;
 
     & iframe,
     & textarea {


### PR DESCRIPTION
Edit: Accidentally forked the read only repo, just pushed update to https://github.com/octobercms/october/pull/905 closing this one, sorry.

If you have an element or give your site's body the color white for fonts, you run into problems when entering the editable `.redactor-box` as it forces a white background but doesn't force a black color to the font. The result is a white font on a white background, not good. This is not a result of using !important anywhere in any of the CSS either, color: #000 is simply not called in the same class that you forced a white background on.

**Here is an example of a design with a dark background and white font:**

![Before](https://s3.amazonaws.com/f.cl.ly/items/3r2o2g1r1G243B0e2g3h/Image%202015-01-22%20at%201.59.10%20AM.png)

**Here is what happens to it when you go to edit it (highlighted some text to show that there is text there):**

![After](https://s3.amazonaws.com/f.cl.ly/items/0V2c1x2S0e053o3u0K0W/Image%202015-01-22%20at%202.01.45%20AM.png)

**Here is what happens when you force the color black on the `.redactor-box`, all fixed:**

![With Modification](https://s3.amazonaws.com/f.cl.ly/items/0Z3I3f3T36362G0w0z2C/Image%202015-01-22%20at%202.04.31%20AM.png)
