### PR TITLE
Added height option for datagrid widget

### DIFF
--- a/widgets/Grid.php
+++ b/widgets/Grid.php
@@ -61,6 +61,11 @@ class Grid extends WidgetBase
     protected $data;
 
     /**
+     * @var integer Height of the grid.
+     */
+    protected $height = 0;
+
+    /**
      * @var string HTML element that can [re]store the grid data, cannot use with data or useDataSource.
      */
     protected $dataLocker;
@@ -89,6 +94,7 @@ class Grid extends WidgetBase
         $this->dataLocker = $this->getConfig('dataLocker', $this->dataLocker);
         $this->useDataSource = $this->getConfig('useDataSource', $this->useDataSource);
         $this->monitorChanges = $this->getConfig('monitorChanges', $this->monitorChanges);
+        $this->height = $this->getConfig('height', $this->height);
     }
 
     /**
@@ -118,6 +124,7 @@ class Grid extends WidgetBase
         $this->vars['dataLocker'] = $this->dataLocker;
         $this->vars['useDataSource'] = $this->useDataSource;
         $this->vars['monitorChanges'] = $this->monitorChanges;
+        $this->vars['height'] = $this->height;
     }
 
     protected function makeToolbarWidget()

--- a/widgets/grid/assets/js/datagrid.js
+++ b/widgets/grid/assets/js/datagrid.js
@@ -67,6 +67,9 @@
         if (this.options.autoInsertRows)
             handsontableOptions.minSpareRows = 1
 
+        if (this.options.height) {
+            handsontableOptions.height = this.options.height;
+        }
         /*
          * Data provided
          */

--- a/widgets/grid/partials/_grid.htm
+++ b/widgets/grid/partials/_grid.htm
@@ -10,6 +10,7 @@
         data-control="datagrid"
         data-allow-remove="<?= $allowRemove ? 'true' : 'false' ?>"
         data-autocomplete-handler="<?= $this->getEventHandler('onAutocomplete') ?>"
+        <?php if ($height): ?>data-height="<?= $height ?>"<?php endif ?>
         <?php if ($dataLocker): ?>data-data-locker="<?= $dataLocker ?>"<?php endif ?>
         <?php if ($useDataSource): ?>data-source-handler="<?= $this->getEventHandler('onDataSource') ?>"<?php endif ?>
         <?php if ($monitorChanges): ?>data-change-handler="<?= $this->getEventHandler('onDataChanged') ?>"<?php endif ?>


### PR DESCRIPTION
The Handsontable jQuery plugin will throw an exception when more than a 1000 rows need to be rendered:

"Security brake: Too much TRs. Please define height for your table, which will enforce scrollbars."

As the error message indicates, this is solved by defining a height on the table.

This exception occurs for example at the Translate plugin backend table, when more than a 1000 website translation messages are present on the website.
